### PR TITLE
added chmod on the file fixing runtime error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM mariadb:10.3
 
 COPY docker-entrypoint.sh /usr/local/bin/
-RUN rm -rf /docker-entrypoint.sh && ln -s /usr/local/bin/docker-entrypoint.sh / 
+RUN rm -rf /docker-entrypoint.sh \
+    && chmod 777 /usr/local/bin/docker-entrypoint.sh \
+    && ln -s /usr/local/bin/docker-entrypoint.sh /
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 EXPOSE 3306


### PR DESCRIPTION
dockerfile was crashing with error:
docker: Error response from daemon: oci runtime error: container_linux.go:247: starting container process caused "exec: \"docker-entrypoint.sh\": executable file not found in $PATH".
added chmod to fix it.